### PR TITLE
Revert removal of paper-shadow.css

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -14,6 +14,7 @@ license that can be found in the LICENSE file.
 
   <script src="../platform/platform.js"></script>
   <link href="paper-shadow.html" rel="import">
+  <link href="paper-shadow.css" rel="import">
 
   <style>
     body {


### PR DESCRIPTION
https://github.com/Polymer/paper-shadow/commit/74473f7c35bb9a88d916cc297955e646ddb394b7 broke the class examples, I opened https://github.com/Polymer/paper-shadow/issues/16 to highlight why this actually happened, as I think its probably unintentional (it seems wrong to me to be including css from a custom element directly).
