### PR TITLE
Change brackets to curly braces

### DIFF
--- a/paper-shadow.html
+++ b/paper-shadow.html
@@ -30,8 +30,8 @@ Example:
 
 <template>
 
-  <div id="shadow-bottom" fit animated?="[[animated]]" class="paper-shadow-bottom-z-[[z]]"></div>
-  <div id="shadow-top" fit animated?="[[animated]]" class="paper-shadow-top-z-[[z]]"></div>
+  <div id="shadow-bottom" fit animated?="{{animated}}" class="paper-shadow-bottom-z-{{z}}"></div>
+  <div id="shadow-top" fit animated?="{{animated}}" class="paper-shadow-top-z-{{z}}"></div>
 
   <content></content>
 


### PR DESCRIPTION
When using <paper-shadow> to wrap a simple element, the shadow only appears if loading or reloading the current page. If you arrive to that page via navigation, the shadow doesn't appear. E.g. reloading my "/login" page has the shadow appear, but clicking the "login" link from my home page to login page shows the element without the shadow.

This is fixed by changing the brackets to curly braces. I'm not sure why it works though. If you could enlighten me that'd be great :-)
