### PR TITLE
Fix test failure caused by design change.

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -42,7 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var fake = new Fake();
 
     test('default', function() {
-      assert.notEqual(getComputedStyle(s1.$['shadow-top'])['box-shadow'], 'none');
+      assert.notEqual(getComputedStyle(s1.$['shadow-bottom'])['box-shadow'], 'none');
     });
 
     test('shadows are pointer-events: none', function(done) {


### PR DESCRIPTION
A design change to the styles related to shadows causes a test failure
in Chrome. The change that caused this test failure also caused a failure
in at least one other element (paper-button) as a side-effect.