### PR TITLE
removed the setZ method

### DIFF
--- a/paper-shadow.html
+++ b/paper-shadow.html
@@ -43,8 +43,7 @@ Example:
     publish: {
 
       /**
-       * The z-depth of this shadow, from 0-5. Setting this property
-       * after element creation has no effect. Use `setZ()` instead.
+       * The z-depth of this shadow, from 0-5.
        *
        * @attribute z
        * @type number
@@ -64,20 +63,16 @@ Example:
 
     },
 
-    /**
-     * Set the z-depth of the shadow. This should be used after element
-     * creation instead of setting the z property directly.
-     *
-     * @method setZ
-     * @param {Number} newZ
-     */
-    setZ: function(newZ) {
-      if (this.z !== newZ) {
-        this.$['shadow-bottom'].classList.remove('paper-shadow-bottom-z-' + this.z);
-        this.$['shadow-bottom'].classList.add('paper-shadow-bottom-z-' + newZ);
-        this.$['shadow-top'].classList.remove('paper-shadow-top-z-' + this.z);
-        this.$['shadow-top'].classList.add('paper-shadow-top-z-' + newZ);
-        this.z = newZ;
+    domReady: function() {
+      this.isDomReady = true;
+    },
+
+    zChanged: function(oldValue, newValue) {
+      if (this.isDomReady) {
+        this.$['shadow-bottom'].classList.remove('paper-shadow-bottom-z-' + oldValue);
+        this.$['shadow-bottom'].classList.add('paper-shadow-bottom-z-' + newValue);
+        this.$['shadow-top'].classList.remove('paper-shadow-top-z-' + oldValue);
+        this.$['shadow-top'].classList.add('paper-shadow-top-z-' + newValue);
       }
     }
 


### PR DESCRIPTION
[Here](https://www.polymer-project.org/0.5/docs/elements/paper-shadow.html#paper-shadow.methods.setZ) you can see that the setZ method is now well documented. This patch removes the setZ method at all and therefore makes API cleaner.