### PR TITLE
Action should be performed only on desired target element

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -114,7 +114,13 @@ license that can be found in the LICENSE file.
   var scope = document.querySelector('template[is=auto-binding]');
 
   scope.tapAction = function(e) {
+
+    if (e.target.nodeName !== "PAPER-SHADOW") { // action should be performed only on desired element
+      return;
+    }
+
     var target = e.target;
+
     if (!target.down) {
       target.setZ(target.z + 1);
       if (target.z === 5) {


### PR DESCRIPTION
tapAction event is attached to the parent element on which we would like to perform action against. This is exactly how it should be done.
But the delegated event should target individual element we want to alter.

If clicking in "section" parent element, without clicking on the element "paper-shadow" will cause an error.